### PR TITLE
Fix deprecation warning

### DIFF
--- a/app/models/maia/device.rb
+++ b/app/models/maia/device.rb
@@ -20,7 +20,7 @@ module Maia
     end
 
     def self.owned_by(pushable)
-      where(pushable: pushable).uniq
+      where(pushable: pushable).distinct
     end
 
     def self.ios

--- a/lib/maia/version.rb
+++ b/lib/maia/version.rb
@@ -1,3 +1,3 @@
 module Maia
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end


### PR DESCRIPTION
Fix .uniq deprecation warning by switching to distinct.

`DEPRECATION WARNING: uniq is deprecated and will be removed from Rails 5.1`