### PR TITLE
raise ActiveRecord::RecordNotFound unless device present

### DIFF
--- a/app/controllers/concerns/maia/controller.rb
+++ b/app/controllers/concerns/maia/controller.rb
@@ -25,9 +25,7 @@ module Maia
       end
 
       def find_device(token = params[:device][:token])
-        device = current_user.devices.find_by token: token
-        raise ActiveRecord::RecordNotFound.new('Device not found') unless device
-        device
+        current_user.devices.find_by! token: token
       end
 
       def update_device(device)

--- a/app/controllers/concerns/maia/controller.rb
+++ b/app/controllers/concerns/maia/controller.rb
@@ -25,7 +25,9 @@ module Maia
       end
 
       def find_device(token = params[:device][:token])
-        current_user.devices.find_by token: token
+        device = current_user.devices.find_by token: token
+        raise ActiveRecord::RecordNotFound.new('Device not found') unless device
+        device
       end
 
       def update_device(device)

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -41,5 +41,11 @@ describe DevicesController do
         user.reload.devices.count
       }.by(-1)
     end
+
+    it 'returns an error message if no device found' do
+      expect {
+        delete :destroy, params: { id: 'none' }
+      }.to raise_error ActiveRecord::RecordNotFound, 'Device not found'
+    end
   end
 end

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -45,7 +45,7 @@ describe DevicesController do
     it 'returns an error message if no device found' do
       expect {
         delete :destroy, params: { id: 'none' }
-      }.to raise_error ActiveRecord::RecordNotFound, 'Device not found'
+      }.to raise_error ActiveRecord::RecordNotFound, /Couldn't find Maia::Device/
     end
   end
 end


### PR DESCRIPTION
Currently if `find_device` fails to return a Device instance and instead returns `nil`, a NoMethodError will later be raised when calling `destroy` on `@device` in: 

```
    def destroy
      @device = find_device params[:id]
      @device.destroy
      respond_with @device
    end
```
That's not the best user experience because of the lack of context around the error. This PR would have an `ActiveRecord::RecordNotFound` with a custom message raised instead in the `find_device` method for better context.