### PR TITLE
Rails 6 support

### DIFF
--- a/lib/maia/version.rb
+++ b/lib/maia/version.rb
@@ -1,3 +1,3 @@
 module Maia
-  VERSION = '4.0.2'.freeze
+  VERSION = '4.0.3'.freeze
 end

--- a/maia.gemspec
+++ b/maia.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', ['>= 5', '< 6']
-  s.add_dependency 'activejob', ['>= 5', '< 6']
+  s.add_dependency 'rails', ['>= 5', '< 7']
+  s.add_dependency 'activejob', ['>= 5', '< 7']
   s.add_dependency 'responders'
 
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Tests when forcing use of AR6+
```
Finished in 0.30653 seconds (files took 3.57 seconds to load)
79 examples, 0 failures
````

Adds rails 6 support. No major breaking changes in AR6, this will technically require ruby 2.5.0 for 6 but we can leave that lack of support to rubygems.
