### PR TITLE
Rails 7 compatibility

### DIFF
--- a/lib/maia/version.rb
+++ b/lib/maia/version.rb
@@ -1,3 +1,3 @@
 module Maia
-  VERSION = '5.0.1'.freeze
+  VERSION = '5.0.2'.freeze
 end

--- a/maia.gemspec
+++ b/maia.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', ['>= 5', '< 7']
-  s.add_dependency 'activejob', ['>= 5', '< 7']
+  s.add_dependency 'rails', ['>= 5', '< 8']
+  s.add_dependency 'activejob', ['>= 5', '< 8']
   s.add_dependency 'responders'
   s.add_dependency 'googleauth'
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -11,8 +11,14 @@ require 'maia'
 
 module Dummy
   class Application < Rails::Application
-    config.assets.enabled = false
+    case Rails::VERSION::MAJOR
+    when 5, 6
+      config.assets.enabled = false
+      config.active_record&.sqlite3&.represent_boolean_as_integer = true
+    when 7
+      config.active_record.legacy_connection_handling = false
+    end
+
     config.active_job.queue_adapter = :inline
-    config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,12 @@ ActiveRecord::Migrator.migrations_paths = [File.expand_path('../../spec/dummy/db
 require 'rspec/rails'
 require 'webmock/rspec'
 
-ActiveRecord::Migration.maintain_test_schema!
+case Rails::VERSION::MAJOR
+when 5, 6
+  ActiveRecord::Migration.maintain_test_schema!
+when 7
+  ActiveRecord.maintain_test_schema = true
+end
 ActiveJob::Base.queue_adapter = :test
 
 RSpec.configure do |config|


### PR DESCRIPTION
Tests pass on latest versions of rails 5, 6, 7.

Some deprecation warnings for a spec setup, but the suggested replacement is not available in 5/6, so I errored on the side of compatibility. The version compatibility checks are in specs or dummy app, so maybe don't need to work around it, but I figured more flexibility the better?

```sh
➜ bin/rspec spec   
/Users/jonworks/.rbenv/versions/2.7.1/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/Users/jonworks/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.2/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/Users/jonworks/.rbenv/versions/2.7.1/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
/Users/jonworks/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.2/lib/net/protocol.rb:208: warning: previous definition of BUFSIZE was here
/Users/jonworks/.rbenv/versions/2.7.1/lib/ruby/2.7.0/net/protocol.rb:503: warning: already initialized constant Net::NetPrivate::Socket
/Users/jonworks/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.2/lib/net/protocol.rb:504: warning: previous definition of Socket was here
..DEPRECATION WARNING: TimeWithZone#to_s(:nsec) is deprecated. Please use TimeWithZone#to_fs(:nsec) instead. (called from block (3 levels) in <top (required)> at /Users/jonworks/Beachy/maia/spec/controllers/devices_controller_spec.rb:21)
DEPRECATION WARNING: TimeWithZone#to_s(:nsec) is deprecated. Please use TimeWithZone#to_fs(:nsec) instead. (called from block (3 levels) in <top (required)> at /Users/jonworks/Beachy/maia/spec/controllers/devices_controller_spec.rb:23)
.................................................................

Finished in 0.44269 seconds (files took 1.6 seconds to load)
67 examples, 0 failures
```
